### PR TITLE
Added flag to show the min and max value beside the half gauge

### DIFF
--- a/gaugelibrary/src/main/java/com/ekn/gruzer/gaugelibrary/AbstractGauge.java
+++ b/gaugelibrary/src/main/java/com/ekn/gruzer/gaugelibrary/AbstractGauge.java
@@ -42,6 +42,7 @@ abstract class AbstractGauge extends View {
     private float padding = 0;
     private RectF rectF;
     private boolean useRangeBGColor = false;
+    private boolean showValueRangeText = false;
 
 
     public AbstractGauge(Context context) {
@@ -298,6 +299,12 @@ abstract class AbstractGauge extends View {
 
     public void setMaxValue(double maxValue) {
         this.maxValue = maxValue;
+    }
+
+    public boolean getshowValueRangeText() { return showValueRangeText; }
+
+    public void setShowValueRangeText(boolean value) {
+        this.showValueRangeText = value;
     }
 
     public double getValue() {

--- a/gaugelibrary/src/main/java/com/ekn/gruzer/gaugelibrary/HalfGauge.java
+++ b/gaugelibrary/src/main/java/com/ekn/gruzer/gaugelibrary/HalfGauge.java
@@ -121,11 +121,14 @@ public class HalfGauge extends AbstractGauge {
 
 
         //draw Text Value
-        drawValueText(canvas);
-        //drawMinValue
-        drawMinValue(canvas);
-        //drawMaxValue
-        drawMaxValue(canvas);
+        //drawValueText(canvas);
+
+        if (getshowValueRangeText()) {
+            //drawMinValue
+            drawMinValue(canvas);
+            //drawMaxValue
+            drawMaxValue(canvas);
+        }
     }
 
     private void drawValueText(Canvas canvas) {


### PR DESCRIPTION
Hi,

I have added a boolean value to show/hide the min and max values beside the half gauge. The boolean value can set from the layout inflater during usage like below.

```
val halfGauge = R.id.halfGauge
halfGauge.minValue = 0.0
halfGauge.maxValue = 100.0
halfGauge.setShowValueRangeText(false)
halfGauge.value = 50.0
```
