### PR TITLE
Make AbstractGauge interface public to allow dynamic instancing

### DIFF
--- a/gaugelibrary/src/main/java/com/ekndev/gaugelibrary/AbstractGauge.java
+++ b/gaugelibrary/src/main/java/com/ekndev/gaugelibrary/AbstractGauge.java
@@ -25,7 +25,7 @@ import com.ekndev.gaugelibrary.contract.ValueFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
-abstract class AbstractGauge extends View {
+public abstract class AbstractGauge extends View {
 
 
     private List<Range> ranges = new ArrayList<>();


### PR DESCRIPTION
Hello, thank you for your nice lib!
I found useful to make AbstractGauge interface public, so if you'd like, you could merge it to your lib.
The use case is instancing gauges dynamically at runtime, when the type of gauge is not known at compile time and cannot be included in a layout file.

Here an usage example (the gauges are configured remotely through a json):
```
                val gaugeView: AbstractGauge = when(gaugeJo.getString("type")) {
                    "half" -> HalfGauge(this)
                    "multi" -> MultiGauge(this)
                    "arc" -> ArcGauge(this)
                    else -> FullGauge(this)
                }
                gaugeContainerView.addView(gaugeView)

                // Set max, min, value
                gaugeView.minValue = gaugeJo.getDouble("min")
                gaugeView.maxValue = gaugeJo.getDouble("max")
                gaugeView.value = gaugeJo.getJSONArray("values").getDouble(0)

                // Set ranges
                val range = Range()
                range.color = Color.parseColor("#00ff00")
                range.from = gaugeJo.getDouble("min")
                range.to = gaugeJo.getDouble("warn")
                gaugeView.addRange(range)
    
                // ... and so on...
```
This is possible only having a supertype (or the interface) common to all gauges.

Thank you!